### PR TITLE
Add attendance impact details to live dashboard

### DIFF
--- a/pages/2_Dashboard.py
+++ b/pages/2_Dashboard.py
@@ -5,7 +5,12 @@ from datetime import date, timedelta
 import pandas as pd
 import streamlit as st
 
-from services.coverage import compute_live_coverage, compute_theoretical_coverage
+from services.coverage import (
+    compute_attendance_impact_details,
+    compute_live_coverage,
+    compute_theoretical_coverage,
+    weeks_in_range,
+)
 from services.data_loader import get_data
 
 
@@ -52,12 +57,14 @@ def main():
             display_mode = st.selectbox("Display mode", list(DISPLAY_MODES.keys()))
             date_range = (start, end)
 
+    unit_value = UNIT_OPTIONS[unit]
+
     if VIEW_OPTIONS[view] == "theoretical":
         df = compute_theoretical_coverage(
             data,
             view=DISPLAY_OPTIONS[display],
             group_by=GROUP_OPTIONS[group_by],
-            unit=UNIT_OPTIONS[unit],
+            unit=unit_value,
         )
     else:
         df = compute_live_coverage(
@@ -66,7 +73,7 @@ def main():
             date_range=date_range,
             display_mode=DISPLAY_MODES.get(display_mode, "coverage"),
             group_by=GROUP_OPTIONS[group_by],
-            unit=UNIT_OPTIONS[unit],
+            unit=unit_value,
         )
 
     if search_term:
@@ -76,6 +83,30 @@ def main():
         df = df[mask]
 
     st.dataframe(_style_dataframe(df), use_container_width=True)
+
+    if VIEW_OPTIONS[view] == "live":
+        weeks = weeks_in_range(date_range)
+        attendance_details = pd.DataFrame()
+        if weeks:
+            selected_week = st.selectbox(
+                "Week",
+                weeks,
+                format_func=lambda d: d.strftime("%Y-W%W"),
+                help="Select a week to review attendance impact details.",
+            )
+            attendance_details = compute_attendance_impact_details(
+                data,
+                attendance=data.get("attendances", []),
+                week_start=selected_week,
+                group_by=GROUP_OPTIONS[group_by],
+                unit=unit_value,
+            )
+
+        st.subheader("Attendance impact details")
+        if attendance_details.empty:
+            st.info("No attendance impact recorded for the selected parameters.")
+        else:
+            st.dataframe(attendance_details, use_container_width=True)
 
 
 if __name__ == "__main__":

--- a/services/coverage.py
+++ b/services/coverage.py
@@ -177,6 +177,129 @@ def _week_range(start: date, end: date) -> List[date]:
     return weeks
 
 
+def weeks_in_range(date_range: Tuple[date, date]) -> List[date]:
+    """Return a list of ISO week starts within ``date_range``.
+
+    The public wrapper allows UI components to display the same weekly buckets
+    used by the live coverage computation without exposing the internal helper
+    directly.
+    """
+
+    return _week_range(*date_range)
+
+
+def compute_attendance_impact_details(
+    data,
+    attendance: List[AttendanceRecord],
+    week_start: date,
+    group_by: str,
+    unit: str,
+) -> pd.DataFrame:
+    """Build a detailed view of attendance impact for a specific week."""
+
+    week_end = week_start + timedelta(days=6)
+
+    impacted_records = [
+        record
+        for record in attendance
+        if record.start_date <= week_end and record.end_date >= week_start
+    ]
+
+    if not impacted_records:
+        return pd.DataFrame(
+            columns=[
+                "Region",
+                "Office",
+                "Employee",
+                "Process",
+                "Reason",
+                f"Adjusted Contribution ({unit.lower()})",
+                f"Base Contribution ({unit.lower()})",
+            ]
+        )
+
+    employees: List[Employee] = data.get("employees", [])
+    allocations: List[Allocation] = data.get("allocations", [])
+    support_allocations: List[SupportAllocation] = data.get("support_allocations", [])
+    offices: List[Office] = data.get("offices", [])
+    processes: List[Process] = data.get("processes", [])
+
+    employee_lookup = _build_lookup(employees, "uuid")
+    office_lookup = _build_lookup(offices, "uuid")
+    process_lookup = _build_lookup(processes, "uuid")
+
+    allocation_lookup: Dict[str, List[Allocation]] = defaultdict(list)
+    for allocation in allocations:
+        allocation_lookup[allocation.employee_uuid].append(allocation)
+
+    support_lookup: Dict[str, List[SupportAllocation]] = defaultdict(list)
+    for support in support_allocations:
+        support_lookup[support.allocation_uuid].append(support)
+
+    detail_rows: List[Dict[str, object]] = []
+
+    for record in impacted_records:
+        employee = employee_lookup.get(record.employee_uuid)
+        if not employee:
+            continue
+
+        office = office_lookup.get(employee.office_uuid)
+        if not office:
+            continue
+
+        factor = _attendance_factor(attendance, employee.uuid, week_start)
+        allocations_for_employee = allocation_lookup.get(employee.uuid, [])
+
+        for allocation in allocations_for_employee:
+            supports = support_lookup.get(allocation.uuid, [])
+            if not supports:
+                continue
+
+            for support in supports:
+                process = process_lookup.get(support.process_uuid)
+                if not process:
+                    continue
+
+                base_contribution = _convert_unit(
+                    _allocation_hours(employee, allocation, support),
+                    unit,
+                )
+                adjusted_contribution = base_contribution * factor
+
+                detail_rows.append(
+                    {
+                        "Region": office.region.value,
+                        "Office": office.name,
+                        "Employee": f"{employee.first_name} {employee.last_name}",
+                        "Process": process.name,
+                        "Reason": record.type.value.title(),
+                        f"Adjusted Contribution ({unit.lower()})": adjusted_contribution,
+                        f"Base Contribution ({unit.lower()})": base_contribution,
+                    }
+                )
+
+    if not detail_rows:
+        return pd.DataFrame(
+            columns=[
+                "Region",
+                "Office",
+                "Employee",
+                "Process",
+                "Reason",
+                f"Adjusted Contribution ({unit.lower()})",
+                f"Base Contribution ({unit.lower()})",
+            ]
+        )
+
+    df = pd.DataFrame(detail_rows)
+
+    if group_by.lower() != "office" and "Office" in df.columns:
+        df = df.drop(columns=["Office"])
+
+    sort_columns = [col for col in ["Region", "Office", "Employee", "Process"] if col in df.columns]
+    return df.sort_values(sort_columns).reset_index(drop=True)
+
+
 def _attendance_factor(attendances: List[AttendanceRecord], employee_uuid: str, week_start: date) -> float:
     week_end = week_start + timedelta(days=6)
     for record in attendances:


### PR DESCRIPTION
## Summary
- expose helper to list weeks in range and compute attendance impact details
- extend live dashboard with week selector and attendance impact table

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d19c5a385c8320a71c7cb67b6d2b69