### PR TITLE
Refine allocation editors and support status handling

### DIFF
--- a/data/processes.json
+++ b/data/processes.json
@@ -6,7 +6,7 @@
     "description": "Handle email tickets",
     "apps_related": ["app-mail"],
     "process_related": [],
-    "support_status": "SUPPORTER"
+    "support_status": "SUPPORTED"
   },
   {
     "uuid": "process-phone",

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -24,8 +24,8 @@ class RoleType(str, Enum):
 
 
 class SupportStatus(str, Enum):
-    SUPPORTER = "SUPPORTER"
-    TBD = "TBD"
+    SUPPORTED = "SUPPORTED"
+    TO_BE_DEFINED = "TO_BE_DEFINED"
     PARTIALLY_SUPPORTED = "PARTIALLY_SUPPORTED"
 
 
@@ -105,7 +105,7 @@ class Process:
     description: str
     apps_related: List[str] = field(default_factory=list)
     process_related: List[str] = field(default_factory=list)
-    support_status: SupportStatus = SupportStatus.TBD
+    support_status: SupportStatus = SupportStatus.TO_BE_DEFINED
 
     @classmethod
     def from_dict(cls, raw: Dict) -> "Process":


### PR DESCRIPTION
## Summary
- switch support status values to SUPPORTED/TO_BE_DEFINED and update seed data accordingly
- improve data management allocation editors with percentage scaling, progress bars, and separate tabs for role vs support details
- streamline scenario planner displays with scenario-only summaries, utilization progress bars, tabbed editors, support status selects, and hidden row numbers

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d44f01d03c832094075d5ed47639a2