### PR TITLE
Fix live view JIRA selection

### DIFF
--- a/pages/2_Dashboard.py
+++ b/pages/2_Dashboard.py
@@ -197,7 +197,6 @@ def main():
                 st.empty()
 
         secondary_row = st.columns([0.8, 1.8, 0.8])
-        selected_display_labels: list[str] = []
         with secondary_row[0]:
             segmented = st.segmented_control(
                 "Group by",


### PR DESCRIPTION
## Summary
- stop resetting the selected display pills when rendering the dashboard controls
- ensure the JIRA option remains selected and updates the live view as expected

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4e90da67c8320a7ce1ba64abc775c