### PR TITLE
Improve allocation and expertise management UX

### DIFF
--- a/pages/4_Expertise_Dashboard.py
+++ b/pages/4_Expertise_Dashboard.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, timedelta
 
 import pandas as pd
 import streamlit as st
@@ -104,6 +104,16 @@ def main() -> None:
         )
         return
 
+    employee_lookup = {
+        employee.uuid: (
+            f"{employee.first_name} {employee.last_name}".strip()
+            or employee.trigram
+            or employee.uuid
+        )
+        for employee in data.get("employees", [])
+    }
+    process_lookup = {process.uuid: process.name for process in data.get("processes", [])}
+
     filter_row = st.columns([1.2, 1.2, 1.0])
     with filter_row[0]:
         as_of = st.date_input(
@@ -162,9 +172,55 @@ def main() -> None:
         st.info("No expertise assignments available for the selected criteria.")
         return
 
+    detail_row = st.columns([1.2, 1.2])
+    with detail_row[0]:
+        employee_options = [None] + sorted(employee_lookup.keys(), key=lambda item: employee_lookup[item])
+        selected_employee_uuid = st.selectbox(
+            "Employee",
+            options=employee_options,
+            format_func=lambda value: "All employees"
+            if value is None
+            else employee_lookup.get(value, value),
+            key="expertise_employee_filter",
+        )
+
+    available_process_ids = sorted(
+        {
+            row.get("Process UUID")
+            for _, row in expertise_df.iterrows()
+            if pd.notna(row.get("Process UUID"))
+            and row.get("Process UUID")
+            and (
+                not selected_employee_uuid
+                or row.get("Employee UUID") == selected_employee_uuid
+            )
+        }
+    )
+
+    process_evolution_key = "expertise_process_evolution"
+    valid_process_values = {None, *available_process_ids}
+    if (
+        process_evolution_key in st.session_state
+        and st.session_state[process_evolution_key] not in valid_process_values
+    ):
+        st.session_state[process_evolution_key] = None
+
+    with detail_row[1]:
+        selected_process_uuid = st.selectbox(
+            "Process (evolution)",
+            options=[None] + available_process_ids,
+            format_func=lambda value: "Select a process"
+            if value is None
+            else process_lookup.get(value, value),
+            key=process_evolution_key,
+        )
+
     filtered_df = expertise_df.copy()
     min_level, max_level = level_range
     filtered_df = filtered_df[(filtered_df["Level"] >= min_level) & (filtered_df["Level"] <= max_level)]
+
+    if selected_employee_uuid:
+        filtered_df = filtered_df[filtered_df["Employee UUID"] == selected_employee_uuid]
 
     if process_filter:
         filtered_df = filtered_df[filtered_df["Process"].isin(process_filter)]
@@ -188,6 +244,65 @@ def main() -> None:
     for idx, level in enumerate(range(1, 6)):
         count = int(summary_levels.get(level, 0))
         summary_columns[idx].metric(f"Level {level}", f"{count}")
+
+    if selected_employee_uuid and selected_process_uuid:
+        employee_label = employee_lookup.get(selected_employee_uuid, "Selected employee")
+        process_label = process_lookup.get(selected_process_uuid, "Selected process")
+        st.markdown(f"#### Expertise evolution for {employee_label} – {process_label}")
+
+        evolution_df = expertise_df[
+            (expertise_df["Employee UUID"] == selected_employee_uuid)
+            & (expertise_df["Process UUID"] == selected_process_uuid)
+        ].sort_values("Start Date")
+
+        if evolution_df.empty:
+            st.info("No expertise history recorded for this combination yet.")
+        else:
+            timeline_points: list[dict[str, object]] = []
+            for _, row in evolution_df.iterrows():
+                start_raw = row.get("Start Date")
+                end_raw = row.get("End Date")
+                level_value = int(row.get("Level", 0))
+                start_value = pd.to_datetime(start_raw, errors="coerce")
+                end_value = pd.to_datetime(end_raw, errors="coerce") if end_raw else None
+                if pd.isna(start_value):
+                    continue
+                start_date_value = start_value.date()
+                end_date_value = end_value.date() if end_value and not pd.isna(end_value) else None
+
+                timeline_points.append({"Date": start_date_value, "Level": level_value})
+
+                if end_date_value:
+                    timeline_points.append({"Date": end_date_value, "Level": level_value})
+                    timeline_points.append(
+                        {"Date": end_date_value + timedelta(days=1), "Level": 0}
+                    )
+                else:
+                    extension_date = as_of if as_of >= start_date_value else start_date_value
+                    timeline_points.append({"Date": extension_date, "Level": level_value})
+                    timeline_points.append({"Date": extension_date + timedelta(days=1), "Level": 0})
+
+            timeline_df = pd.DataFrame(timeline_points)
+            timeline_df = timeline_df.dropna(subset=["Date"])
+            if timeline_df.empty:
+                st.info("No timeline data available for the selected expertise history.")
+            else:
+                timeline_df = timeline_df.sort_values("Date")
+                timeline_df = timeline_df.drop_duplicates(subset=["Date"], keep="last")
+                timeline_df = timeline_df.set_index("Date")
+                st.line_chart(timeline_df, use_container_width=True, height=260)
+
+                history_columns = [
+                    "Start Date",
+                    "End Date",
+                    "Level",
+                    "Active",
+                ]
+                history_df = evolution_df[history_columns].copy()
+                history_df["Start Date"] = history_df["Start Date"].apply(_format_date)
+                history_df["End Date"] = history_df["End Date"].apply(_format_date)
+                history_df["Active"] = history_df["Active"].map({True: "Yes", False: "No"})
+                st.dataframe(history_df, use_container_width=True, hide_index=True)
 
     overview_tabs = st.tabs(["Assignments", "Matrix", "Process summary"])
 


### PR DESCRIPTION
## Summary
- add checkbox-driven row selection to allocation management screens and render allocation percentages with progress indicators
- introduce an active-only filter for expertise records so hidden entries keep their UUIDs and can be saved without manual identifiers
- expand the expertise dashboard with employee filtering plus a per-process evolution chart and history table

## Testing
- python -m compileall .
- python -m compileall pages/1_Data_Management.py pages/3_Scenario_Planner.py
- python -m compileall pages/4_Expertise_Dashboard.py

------
https://chatgpt.com/codex/tasks/task_e_68d4fd896d04832098981e1c2caeaf34