### PR TITLE
Consolidate dashboard into single page

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,16 +3,41 @@ from __future__ import annotations
 import streamlit as st
 
 from services.data_loader import initialize_session_state
+from sections import (
+    coverage_dashboard,
+    data_management,
+    expertise_dashboard,
+    scenario_planner,
+)
+
+SECTIONS = {
+    "Data management": data_management.render,
+    "Coverage dashboard": coverage_dashboard.render,
+    "Scenario planner": scenario_planner.render,
+    "Expertise dashboard": expertise_dashboard.render,
+}
 
 
 def main() -> None:
     st.set_page_config(page_title="Resource Allocation Dashboard", layout="wide")
     initialize_session_state()
+
+    st.sidebar.title("Navigation")
+    selected_label = st.sidebar.radio(
+        "Select a view",
+        options=list(SECTIONS.keys()),
+        index=0,
+        help="Switch between the data management tools, coverage analytics, scenarios, and expertise overview.",
+    )
+
     st.title("Resource Allocation Dashboard")
     st.write(
         "Use the navigation sidebar to manage data, explore coverage dashboards, and evaluate scenarios."
     )
     st.caption("Data is loaded from local JSON fixtures on startup.")
+
+    render_section = SECTIONS[selected_label]
+    render_section()
 
 
 if __name__ == "__main__":

--- a/sections/coverage_dashboard.py
+++ b/sections/coverage_dashboard.py
@@ -31,9 +31,6 @@ STATIC_COLUMN_STYLE = {
     "color": "#111827",
 }
 
-st.set_page_config(page_title="Dashboard", layout="wide")
-
-
 def _default_date_range() -> tuple[date, date]:
     today = date.today()
     start = today - timedelta(days=today.weekday())
@@ -140,7 +137,7 @@ def _style_dataframe(
     return styler
 
 
-def main():
+def render() -> None:
     st.title("Dashboard")
     data = get_data()
 
@@ -303,4 +300,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    import streamlit as st
+
+    st.set_page_config(page_title="Dashboard", layout="wide")
+    render()

--- a/sections/data_management.py
+++ b/sections/data_management.py
@@ -28,10 +28,6 @@ from utils.notifications import notify
 
 from uuid import uuid4
 
-st.set_page_config(page_title="Data Management", layout="wide")
-
-
-
 def _serialize_value(value: Any):
     if hasattr(value, "value"):
         return value.value
@@ -843,7 +839,7 @@ def render_expertise(
     )
 
 
-def main():
+def render() -> None:
     st.title("Data Management")
     data = get_data()
     tabs = st.tabs(
@@ -888,4 +884,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    import streamlit as st
+
+    st.set_page_config(page_title="Data Management", layout="wide")
+    render()

--- a/sections/expertise_dashboard.py
+++ b/sections/expertise_dashboard.py
@@ -8,9 +8,6 @@ import matplotlib
 from services.data_loader import get_data
 from services.expertise import build_expertise_dataframe
 
-st.set_page_config(page_title="Expertise Dashboard", layout="wide")
-
-
 def _format_date(value: object) -> str:
     if isinstance(value, date):
         return value.isoformat()
@@ -93,7 +90,7 @@ def _render_process_summary(filtered_df: pd.DataFrame) -> None:
     st.dataframe(process_summary, use_container_width=True)
 
 
-def main() -> None:
+def render() -> None:
     st.title("Expertise Dashboard")
     data = get_data()
 
@@ -323,5 +320,8 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    import streamlit as st
+
+    st.set_page_config(page_title="Expertise Dashboard", layout="wide")
+    render()
 

--- a/sections/scenario_planner.py
+++ b/sections/scenario_planner.py
@@ -24,9 +24,6 @@ from utils.relations import (
 )
 from utils.styling import coverage_style
 
-st.set_page_config(page_title="Scenario", layout="wide")
-
-
 DIFF_COLUMN_LABEL = "Diff vs baseline"
 
 DISPLAY_DATASETS: List[Tuple[str, str]] = [
@@ -1840,7 +1837,7 @@ def _collection_for_adjustment(adjustment_type: AdjustmentType) -> str:
     raise KeyError(f"Unknown adjustment type: {adjustment_type}")
 
 
-def main():
+def render() -> None:
     st.title("Scenario Planner")
 
     data = get_data()
@@ -1949,4 +1946,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    import streamlit as st
+
+    st.set_page_config(page_title="Scenario", layout="wide")
+    render()


### PR DESCRIPTION
## Summary
- move the former Streamlit multipage scripts into a reusable `sections` package
- drive the application from `main.py` with a sidebar radio selector for the four dashboards
- ensure each section exposes a `render()` entry point and keeps its own title/layout logic

## Testing
- python -m compileall main.py sections

------
https://chatgpt.com/codex/tasks/task_e_68d50ddfd27c832090f8bf89fd044162