### PR TITLE
Add sidebar button to refresh datasets

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import streamlit as st
 
-from services.data_loader import initialize_session_state
+from services.data_loader import initialize_session_state, refresh_data
 from sections import (
     coverage_dashboard,
     data_management,
@@ -23,6 +23,9 @@ def main() -> None:
     initialize_session_state()
 
     st.sidebar.title("Navigation")
+    if st.sidebar.button("Refresh data", help="Reload the datasets from disk."):
+        refresh_data()
+        st.sidebar.success("Data reloaded from source files.")
     selected_label = st.sidebar.selectbox(
         "Select a view",
         options=list(SECTIONS.keys()),


### PR DESCRIPTION
## Summary
- add helper utilities in the data loader to reload datasets and clear cached Jira counts
- expose a sidebar button in the main app to trigger dataset refreshes from disk

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d5122eda0c8320b30dec3f00d06d12